### PR TITLE
Fix a broken link to a drug use survey

### DIFF
--- a/ca_police_scorecard.ipynb
+++ b/ca_police_scorecard.ipynb
@@ -669,7 +669,7 @@
    "source": [
     "# Drug Arrest Disparities\n",
     "\n",
-    "Since [rates of drug use are similar across racial groups](https://store.samhsa.gov/system/files/nsduhresults2013.pdf), disparities in arrests for drug possession suggest racial bias in policing.\n",
+    "Since [rates of drug use are similar across racial groups](https://www.samhsa.gov/data/sites/default/files/NSDUHresultsPDFWHTML2013/Web/NSDUHresults2013.pdf), disparities in arrests for drug possession suggest racial bias in policing.\n",
     "\n",
     "The disparities for Black and Latinx drug arrests are calculated using the following formulae for each municipal police department in California:\n",
     "\n",


### PR DESCRIPTION
While reading through, I saw that https://store.samhsa.gov/system/files/nsduhresults2013.pdf led to a "Page Not Found" landing page. Doing a Google search for the same PDF name I found the same site hosted it at a different URL and updated the notebook to point to the new link. https://www.samhsa.gov/data/sites/default/files/NSDUHresultsPDFWHTML2013/Web/NSDUHresults2013.pdf